### PR TITLE
Add query_with_text_format fn

### DIFF
--- a/postgres-types/src/type_gen.rs
+++ b/postgres-types/src/type_gen.rs
@@ -13,6 +13,7 @@ pub struct Other {
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub enum Inner {
+    Unspecified,
     Bool,
     Bytea,
     Char,
@@ -204,6 +205,7 @@ pub enum Inner {
 impl Inner {
     pub fn from_oid(oid: Oid) -> Option<Inner> {
         match oid {
+            0 => Some(Inner::Unspecified),
             16 => Some(Inner::Bool),
             17 => Some(Inner::Bytea),
             18 => Some(Inner::Char),
@@ -395,6 +397,7 @@ impl Inner {
 
     pub fn oid(&self) -> Oid {
         match *self {
+            Inner::Unspecified => 0,
             Inner::Bool => 16,
             Inner::Bytea => 17,
             Inner::Char => 18,
@@ -586,6 +589,7 @@ impl Inner {
 
     pub fn kind(&self) -> &Kind {
         match *self {
+            Inner::Unspecified => &Kind::Simple,
             Inner::Bool => &Kind::Simple,
             Inner::Bytea => &Kind::Simple,
             Inner::Char => &Kind::Simple,
@@ -777,6 +781,7 @@ impl Inner {
 
     pub fn name(&self) -> &str {
         match *self {
+            Inner::Unspecified => "unspecified",
             Inner::Bool => "bool",
             Inner::Bytea => "bytea",
             Inner::Char => "char",
@@ -967,6 +972,9 @@ impl Inner {
     }
 }
 impl Type {
+    /// Unspecified
+    pub const UNSPECIFIED: Type = Type(Inner::Unspecified);
+
     /// BOOL - boolean, &#39;true&#39;/&#39;false&#39;
     pub const BOOL: Type = Type(Inner::Bool);
 

--- a/postgres/src/client.rs
+++ b/postgres/src/client.rs
@@ -7,7 +7,7 @@ use std::task::Poll;
 use std::time::Duration;
 use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};
 use tokio_postgres::types::{BorrowToSql, ToSql, Type};
-use tokio_postgres::{Error, Row, SimpleQueryMessage, Socket};
+use tokio_postgres::{Error, FormatCode, Row, SimpleQueryMessage, Socket};
 
 /// A synchronous PostgreSQL client.
 pub struct Client {
@@ -251,9 +251,9 @@ impl Client {
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
-        let stream = self
-            .connection
-            .block_on(self.client.query_raw(query, params))?;
+        let stream =
+            self.connection
+                .block_on(self.client.query_raw(query, params, FormatCode::Binary))?;
         Ok(RowIter::new(self.connection.as_ref(), stream))
     }
 

--- a/tokio-postgres/src/bind.rs
+++ b/tokio-postgres/src/bind.rs
@@ -2,7 +2,7 @@ use crate::client::InnerClient;
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::types::BorrowToSql;
-use crate::{query, Error, Portal, Statement};
+use crate::{query, Error, FormatCode, Portal, Statement};
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -22,7 +22,7 @@ where
 {
     let name = format!("p{}", NEXT_ID.fetch_add(1, Ordering::SeqCst));
     let buf = client.with_buf(|buf| {
-        query::encode_bind(&statement, params, &name, buf)?;
+        query::encode_bind(&statement, params, &name, FormatCode::Binary, buf)?;
         frontend::sync(buf);
         Ok(buf.split().freeze())
     })?;

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -266,7 +266,7 @@ impl Client {
             .await
     }
 
-    /// Executes a statement, returning a vector of the resulting rows in Text Format.
+    /// Executes a statement, returning a vector of the resulting rows in the specified Format.
     ///
     /// A statement may contain parameters, specified by `$n`, where `n` is the index of the parameter of the list
     /// provided, 1-indexed.
@@ -274,15 +274,16 @@ impl Client {
     /// The `statement` argument can either be a `Statement`, or a raw query string. If the same statement will be
     /// repeatedly executed (perhaps with different query parameters), consider preparing the statement up front
     /// with the `prepare` method.
-    pub async fn query_with_text_format<T>(
+    pub async fn query_with_format<T>(
         &self,
         statement: &T,
         params: &[&(dyn ToSql + Sync)],
+        result_format: FormatCode,
     ) -> Result<Vec<Row>, Error>
     where
         T: ?Sized + ToStatement,
     {
-        self.query_raw(statement, slice_iter(params), FormatCode::Text)
+        self.query_raw(statement, slice_iter(params), result_format)
             .await?
             .try_collect()
             .await

--- a/tokio-postgres/src/copy_in.rs
+++ b/tokio-postgres/src/copy_in.rs
@@ -2,7 +2,7 @@ use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::query::extract_row_affected;
-use crate::{query, slice_iter, Error, Statement};
+use crate::{query, slice_iter, Error, FormatCode, Statement};
 use bytes::{Buf, BufMut, BytesMut};
 use futures_channel::mpsc;
 use futures_util::{future, ready, Sink, SinkExt, Stream, StreamExt};
@@ -194,7 +194,7 @@ where
 {
     debug!("executing copy in statement {}", statement.name());
 
-    let buf = query::encode(client, &statement, slice_iter(&[]))?;
+    let buf = query::encode(client, &statement, slice_iter(&[]), FormatCode::Binary)?;
 
     let (mut sender, receiver) = mpsc::channel(1);
     let receiver = CopyInReceiver::new(receiver);

--- a/tokio-postgres/src/copy_out.rs
+++ b/tokio-postgres/src/copy_out.rs
@@ -1,7 +1,7 @@
 use crate::client::{InnerClient, Responses};
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
-use crate::{query, slice_iter, Error, Statement};
+use crate::{query, slice_iter, Error, FormatCode, Statement};
 use bytes::Bytes;
 use futures_util::{ready, Stream};
 use log::debug;
@@ -14,7 +14,7 @@ use std::task::{Context, Poll};
 pub async fn copy_out(client: &InnerClient, statement: Statement) -> Result<CopyOutStream, Error> {
     debug!("executing copy out statement {}", statement.name());
 
-    let buf = query::encode(client, &statement, slice_iter(&[]))?;
+    let buf = query::encode(client, &statement, slice_iter(&[]), FormatCode::Binary)?;
     let responses = start(client, buf).await?;
     Ok(CopyOutStream {
         responses,

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -1,6 +1,6 @@
 use crate::query::RowStream;
 use crate::types::{BorrowToSql, ToSql, Type};
-use crate::{Client, Error, Row, Statement, ToStatement, Transaction};
+use crate::{Client, Error, FormatCode, Row, Statement, ToStatement, Transaction};
 use async_trait::async_trait;
 
 mod private {
@@ -133,7 +133,7 @@ impl GenericClient for Client {
         I: IntoIterator<Item = P> + Sync + Send,
         I::IntoIter: ExactSizeIterator,
     {
-        self.query_raw(statement, params).await
+        self.query_raw(statement, params, FormatCode::Binary).await
     }
 
     async fn prepare(&self, query: &str) -> Result<Statement, Error> {

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -119,7 +119,7 @@
 #![warn(rust_2018_idioms, clippy::all, missing_docs)]
 
 pub use crate::cancel_token::CancelToken;
-pub use crate::client::Client;
+pub use crate::client::{Client, FormatCode};
 pub use crate::config::Config;
 pub use crate::connection::Connection;
 pub use crate::copy_in::CopyInSink;

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -9,7 +9,7 @@ use crate::types::{BorrowToSql, ToSql, Type};
 #[cfg(feature = "runtime")]
 use crate::Socket;
 use crate::{
-    bind, query, slice_iter, CancelToken, Client, CopyInSink, Error, Portal, Row,
+    bind, query, slice_iter, CancelToken, Client, CopyInSink, Error, FormatCode, Portal, Row,
     SimpleQueryMessage, Statement, ToStatement,
 };
 use bytes::Buf;
@@ -146,7 +146,9 @@ impl<'a> Transaction<'a> {
         I: IntoIterator<Item = P>,
         I::IntoIter: ExactSizeIterator,
     {
-        self.client.query_raw(statement, params).await
+        self.client
+            .query_raw(statement, params, FormatCode::Binary)
+            .await
     }
 
     /// Like `Client::execute`.


### PR DESCRIPTION
Adds support for specifying a FormatCode and creates a new function to query with text format.

Defaults to Binary for all operations except the new function. Current behaviour and tests should be unchanged.
