### PR TITLE
simple_query command tag

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -261,7 +261,10 @@ impl CommandTag {
 
     /// The number of affected rows
     pub fn rows(&self) -> u64 {
-        self.0.rsplit(' ').next().unwrap().parse().unwrap_or(0)
+        self.0
+            .rsplit(' ')
+            .next()
+            .map_or(0, |w| w.parse().unwrap_or(0))
     }
 
     /// The tag

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -247,7 +247,22 @@ pub enum SimpleQueryMessage {
     /// A statement in the query has completed.
     ///
     /// The command tag and number of rows modified or selected is returned.
-    CommandComplete { tag: String, rows: u64 },
+    CommandComplete(CommandTag),
+}
+
+/// Command Tag returned by the `SimpleQuery` stream.
+#[derive(Debug)]
+pub struct CommandTag(String);
+
+impl CommandTag {
+    pub(crate) fn new(tag: impl ToString) -> Self {
+        Self(tag.to_string())
+    }
+
+    /// The number of affected rows
+    pub fn rows(&self) -> u64 {
+        self.0.rsplit(' ').next().unwrap().parse().unwrap_or(0)
+    }
 }
 
 fn slice_iter<'a>(

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -246,8 +246,8 @@ pub enum SimpleQueryMessage {
     Row(SimpleQueryRow),
     /// A statement in the query has completed.
     ///
-    /// The number of rows modified or selected is returned.
-    CommandComplete(u64),
+    /// The command tag and number of rows modified or selected is returned.
+    CommandComplete { tag: String, rows: u64 },
 }
 
 fn slice_iter<'a>(

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -263,6 +263,11 @@ impl CommandTag {
     pub fn rows(&self) -> u64 {
         self.0.rsplit(' ').next().unwrap().parse().unwrap_or(0)
     }
+
+    /// The tag
+    pub fn tag(&self) -> String {
+        self.0.to_string()
+    }
 }
 
 fn slice_iter<'a>(

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -318,12 +318,12 @@ async fn simple_query() {
         .await
         .unwrap();
 
-    match messages[0] {
-        SimpleQueryMessage::CommandComplete(0) => {}
+    match &messages[0] {
+        SimpleQueryMessage::CommandComplete { tag, rows: 0 } => {}
         _ => panic!("unexpected message"),
     }
-    match messages[1] {
-        SimpleQueryMessage::CommandComplete(2) => {}
+    match &messages[1] {
+        SimpleQueryMessage::CommandComplete { tag, rows: 2 } => {}
         _ => panic!("unexpected message"),
     }
     match &messages[2] {
@@ -344,8 +344,8 @@ async fn simple_query() {
         }
         _ => panic!("unexpected message"),
     }
-    match messages[4] {
-        SimpleQueryMessage::CommandComplete(2) => {}
+    match &messages[4] {
+        SimpleQueryMessage::CommandComplete { tag, rows: 2 } => {}
         _ => panic!("unexpected message"),
     }
     assert_eq!(messages.len(), 5);

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -319,11 +319,15 @@ async fn simple_query() {
         .unwrap();
 
     match &messages[0] {
-        SimpleQueryMessage::CommandComplete { tag, rows: 0 } => {}
+        SimpleQueryMessage::CommandComplete(tag) => {
+            assert_eq!(tag.rows(), 0)
+        }
         _ => panic!("unexpected message"),
     }
     match &messages[1] {
-        SimpleQueryMessage::CommandComplete { tag, rows: 2 } => {}
+        SimpleQueryMessage::CommandComplete(tag) => {
+            assert_eq!(tag.rows(), 2)
+        }
         _ => panic!("unexpected message"),
     }
     match &messages[2] {
@@ -345,7 +349,9 @@ async fn simple_query() {
         _ => panic!("unexpected message"),
     }
     match &messages[4] {
-        SimpleQueryMessage::CommandComplete { tag, rows: 2 } => {}
+        SimpleQueryMessage::CommandComplete(tag) => {
+            assert_eq!(tag.rows(), 2)
+        }
         _ => panic!("unexpected message"),
     }
     assert_eq!(messages.len(), 5);


### PR DESCRIPTION
for simple_query, CommandComplete(tag) now contains a new CommandTag struct. This lets the client introspect the actual tag that was received.